### PR TITLE
Make test suite use existing env

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -98,6 +98,7 @@ class FixtureProject:
                 sys.executable,
                 "-m",
                 "build",
+                "--no-isolation",
                 "--wheel",
                 "--config-setting",
                 "display_debug=true",


### PR DESCRIPTION
Don't build test packages in separate venvs
- permits network-less builds
- much faster